### PR TITLE
 Camera: Handle duplicate camera Id due to openLegacy support

### DIFF
--- a/services/camera/libcameraservice/common/CameraProviderManager.cpp
+++ b/services/camera/libcameraservice/common/CameraProviderManager.cpp
@@ -631,7 +631,12 @@ status_t CameraProviderManager::ProviderInfo::addDevice(const std::string& name,
 
     mUniqueCameraIds.insert(id);
     if (isAPI1Compatible) {
-        mUniqueAPI1CompatibleCameraIds.push_back(id);
+        // addDevice can be called more than once for the same camera id if HAL
+        // supports openLegacy.
+        if (std::find(mUniqueAPI1CompatibleCameraIds.begin(), mUniqueAPI1CompatibleCameraIds.end(),
+                id) == mUniqueAPI1CompatibleCameraIds.end()) {
+            mUniqueAPI1CompatibleCameraIds.push_back(id);
+        }
     }
 
     if (parsedId != nullptr) {


### PR DESCRIPTION
When HAL supports openLegacy, same camera id can be added more than
once.

Because we now use vector to store API1 compatible camera ids, make
sure no duplicate strings are added.

Test: Vendor camera app using openLegacy, Camera CTS
Change-Id: Icb47644ebab5244b6c655840cbf52b180c3698a1